### PR TITLE
Updated test for macOS

### DIFF
--- a/test/unit/hny/shift
+++ b/test/unit/hny/shift
@@ -8,7 +8,7 @@ set -e
 [ -h "${HNY_PREFIX}/archive" ]
 [ -h "${HNY_PREFIX}/arxiv" ]
 
-basename `realpath -- "${HNY_PREFIX}/archive"`
-basename `realpath -- "${HNY_PREFIX}/arxiv"`
+basename -- `readlink -- "${HNY_PREFIX}/archive"`
+basename -- `readlink -- "${HNY_PREFIX}/arxiv"`
 
 

--- a/test/unit/hny/shift.expected
+++ b/test/unit/hny/shift.expected
@@ -1,2 +1,2 @@
 archive-1.0.0
-archive-1.0.0
+archive


### PR DESCRIPTION
realpath wasn't recognized by macOS and forced the TestHoneyShift to fail. Replaced it with readlink.